### PR TITLE
support for hidden timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,16 @@ This module manages GRUB 2 bootloader
 - **BOOL** : *false*
 
 #### gfxmode
-- Define which resolution shoule be used if VBE is used
+- Define which resolution should be used if VBE is used
 - **STRING** : *Empty by default*
+
+#### hidden_timeout
+- Define how long (in seconds) grub should wait for a user to enter the menu
+- **STRING** : *Not present in config file by default*
+
+#### hidden_timeout_quiet
+- Define if the hidden timeout is quiet or not
+- **BOOL** : *Not present in config file unless explicitly defined with true or false* 
 
 #### install_grub
 - Install the GRUB packages and install GRUB in the MBR
@@ -58,7 +66,7 @@ This module manages GRUB 2 bootloader
 - **STRING** : *Empty by default*
 
 #### timeout
-- Define how many time (in second) that the menu should appears
+- Define how long (in seconds) the menu should appear
 - **STRING** : *5*
 
 #### tune
@@ -83,4 +91,6 @@ This module manages GRUB 2 bootloader
       disable_recovery          => true,
       tune                      => '480 440 1',
       device_install            => '/dev/sda',
+      hidden_timeout            => 0,
+      hidden_timeout_quiet      => false,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,8 @@ class grub2 (
   $disable_uuid          = $grub2::params::disable_uuid,
   $distributor           = $grub2::params::distributor,
   $gfxmode               = $grub2::params::gfxmode,
+  $hidden_timeout        = $grub2::params::hidden_timeout,
+  $hidden_timeout_quiet  = $grub2::params::hidden_timeout_quiet,
   $install_binary        = $grub2::params::install_binary,
   $install_grub          = $grub2::params::install_grub,
   $package_ensure        = $grub2::params::package_ensure,
@@ -141,6 +143,8 @@ class grub2 (
   validate_bool($disable_uuid)
   validate_string($distributor)
   validate_string($gfxmode)
+  validate_string($hidden_timeout)
+  validate_string($hidden_timeout_quiet)
   validate_string($install_binary)
   validate_bool($install_grub)
   validate_string($package_ensure)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,8 @@ class grub2::params {
   $disable_uuid          = false
   $disable_recovery      = false
   $gfxmode               = ''
+  $hidden_timeout        = undef
+  $hidden_timeout_quiet  = undef
   $install_grub          = false
   $package_ensure        = 'present'
   $serial_command        = ''

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -3,6 +3,8 @@
 
 GRUB_DEFAULT=<%= @default_entry %>
 GRUB_TIMEOUT=<%= @timeout %>
+<% if @hidden_timeout != nil -%>GRUB_HIDDEN_TIMEOUT=<%= @hidden_timeout %><% end -%>
+<% if @hidden_timeout_quiet != nil -%>GRUB_HIDDEN_TIMEOUT_QUIET="<%= @hidden_timeout_quiet %>"<% end -%>
 GRUB_DISTRIBUTOR=<%= @distributor %>
 <% if !@cmdline_linux_default.empty? -%>
 GRUB_CMDLINE_LINUX_DEFAULT="<%= @cmdline_linux_default %>"


### PR DESCRIPTION
To be able to set the GRUB_HIDDEN_TIMEOUT and GURB_HIDDEN_TIMEOUT_QUIET parameters I updated the package and the docs; if these parameters are not explicitly set, they will not appear in the grub config file and thus the config file should be identical to the current version of the package.

Tested on Ubuntu Server 12 and 14
