### PR TITLE
Add support for GRUB_RECORDFAIL_TIMEOUT option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2015-10-06  Andrew Langhorn - ajlanghorn <andrew@ajlanghorn.com> 0.0.5
+  - Add GRUB_RECORDFAIL_TIMEOUT options
+
 2015-10-05  Gaëtan Trellu - goldyfruit <gaetan.trellu@incloudus.com> 0.0.4
   - This version fix an issue on the Puppet Forge, the module is not download as the lastest version
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ This module manages GRUB 2 bootloader
 - Puppet stuff, define in which state should be the GRUB packages
 - **STRING** : *'present'*
 
+####  recordfail_timeout
+- Set default timeout value for GRUB2.
+  Useful to stop headless machines stalling during boot.
+- **STRING** : *Empty by default*
+
 ####  serial_command
 - Set settings for the serial console
 - **STRING** : *Empty by default*

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,11 @@
 #   Puppet stuff, define in which state should be the GRUB packages
 #   STRING : 'present'
 #
+# [*recordfail_timeout*]
+#   Set default timeout value for GRUB2.
+#   Without this set, headless machines may stall during boot.
+#   STRING : undef
+#
 # [*serial_command*]
 #   Set settings for the serial console
 #   STRING : Empty by default
@@ -135,6 +140,7 @@ class grub2 (
   $install_grub          = $grub2::params::install_grub,
   $package_ensure        = $grub2::params::package_ensure,
   $package_name          = $grub2::params::package_name,
+  $recordfail_timeout    = $grub2::params::recordfail_timeout,
   $serial_command        = $grub2::params::serial_command,
   $terminal              = $grub2::params::terminal,
   $timeout               = $grub2::params::timeout,
@@ -161,6 +167,7 @@ class grub2 (
   validate_bool($install_grub)
   validate_string($package_ensure)
   validate_array($package_name)
+  validate_integer($recordfail_timeout)
   validate_string($serial_command)
   validate_string($terminal)
   validate_string($timeout)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class grub2::params {
   $hidden_timeout_quiet  = undef
   $install_grub          = false
   $package_ensure        = 'present'
+  $recordfail_timeout    = undef
   $serial_command        = ''
   $terminal              = ''
   $timeout               = 5

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -18,6 +18,9 @@ GRUB_CMDLINE_LINUX_DEFAULT="<%= @cmdline_linux_default %>"
 GRUB_CMDLINE_LINUX="<%= @cmdline_linux %>"
 <% else %>GRUB_CMDLINE_LINUX=""
 <% end -%>
+<% if @recordfail_timeout != nil -%>
+GRUB_RECORDFAIL_TIMEOUT="<%= @recordfail_timeout %>"
+<% end -%>
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains


### PR DESCRIPTION
GRUB2 includes a RECORDFAIL feature which means that the boot after a failed boot
will always stop at the boot menu. We can set a timeout value to stop headless systems
failing at this point. There is a difference between the TIMEOUT and RECORDFAIL_TIMEOUT
features, as the former will occur on all boots; the latter occurs only on the boot after a failed boot.

The GRUB_RECORDFAIL_TIMEOUT option allows users to set a default timeout
value to occur should a system running GRUB2 not receive any input at all at
a prompt. If the timeout value is reached, the system continues to boot
using whatever the first or otherwise selected option is. This is a
particularly useful setting on headless systems where stalling boots can cause
pain.

GRUB_RECORDFAIL_TIMEOUT takes an integer as it's value, which is the time in
seconds to wait before timing out and continuing the boot sequence.

This commit:
  - allows for recordfail_timeout to be set
  - validates that the value of recordfail_timeout is a string
  - adds the config option and value to the GRUB2 config, if set