### PR TITLE
Require puppetlabs/stdlib >=4.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,6 @@
     {"operatingsystem": "CentOS"}
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.6.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
The version of puppetlabs/stdlib required to run this module is now greater
than or equal to 4.6.0 since 75c8841526af9d76e8cdae1cf2b26ef3e6915f4a
introduced the use of `validate_integer` which was released in
https://github.com/puppetlabs/puppetlabs-stdlib/commit/260c1f4b92113a1da3b30562a11d20a79e5b08db.

Updates metadata.json.
Fixes #10.