### PR TITLE
Remove duplicate keys

### DIFF
--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -37,7 +37,7 @@ GRUB_TERMINAL="<%= @terminal %>"
 <% end -%>
 <% if !@serial_command.empty? -%>
 GRUB_SERIAL_COMMAND="<%= @serial_command %>"
-<% else %>#GRUB_SERIAL_COMMAND=""
+<% else %>
 <% end -%>
 
 # The resolution used on graphical terminal

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -57,13 +57,13 @@ GRUB_DISABLE_LINUX_UUID="true"
 # Uncomment to disable generation of recovery mode menu entries
 <% if @disable_recovery -%>
 GRUB_DISABLE_RECOVERY="true"
-<% else %>#GRUB_DISABLE_RECOVERY="true"
+<% else %>
 <% end -%>
 
 # Uncomment to disable generation of submenu
 <% if @disable_submenu -%>
 GRUB_DISABLE_SUBMENU="true"
-<% else %>#GRUB_DISABLE_RECOVERY="true"
+<% else %>
 <% end -%>
 
 # Uncomment to get a beep at grub start


### PR DESCRIPTION
I've just spent a few minutes cleaning up a diff because there were duplicate keys and new additions that weren't present in the default `/etc/default/grub`. Having keys that are commented out is superfluous, because these keys aren't enabled as there is no value set. If a value is set, they can be re-introduced automatically.