### PR TITLE
Remove duplicate keys

### DIFF
--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -53,16 +53,12 @@ GRUB_DISABLE_LINUX_UUID="true"
 <% else %>#GRUB_DISABLE_LINUX_UUID="true"
 <% end -%>
 
-# Uncomment to disable generation of recovery mode menu entries
 <% if @disable_recovery -%>
 GRUB_DISABLE_RECOVERY="true"
-<% else %>#GRUB_DISABLE_RECOVERY="true"
 <% end -%>
 
-# Uncomment to disable generation of submenu
 <% if @disable_submenu -%>
 GRUB_DISABLE_SUBMENU="true"
-<% else %>#GRUB_DISABLE_RECOVERY="true"
 <% end -%>
 
 # Uncomment to get a beep at grub start

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -37,7 +37,6 @@ GRUB_TERMINAL="<%= @terminal %>"
 <% end -%>
 <% if !@serial_command.empty? -%>
 GRUB_SERIAL_COMMAND="<%= @serial_command %>"
-<% else %>#GRUB_SERIAL_COMMAND=""
 <% end -%>
 
 # The resolution used on graphical terminal

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -67,8 +67,7 @@ GRUB_INIT_TUNE="<%= @tune %>"
 <% else %>#GRUB_INIT_TUNE="480 440 1"
 <% end -%>
 
-# Uncomment to set Xen boot parameters
 <% if !@cmdline_xen.empty? -%>
 GRUB_CMDLINE_XEN="<%= @cmdline_xen %>"
-<% else %>#GRUB_CMDLINE_XEN="dom0_mem=1024M,max:1024M"
+<% else %>
 <% end -%>


### PR DESCRIPTION
Removes duplicate and superfluous GRUB2 configuration options by only ensuring that defaults are present where they were present in the origin `/etc/default/grub` file. Any additional have been removed to make diffing easier.