### PR TITLE
Add support for cryptodisks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ This module manages GRUB 2 bootloader
 - Define if GRUB should display the submenu
 - **BOOL** : *false*
 
+#### enable_cryptodisk
+- Define if GRUB should check for encrypted disks and generate additional
+  commands needed to access them during boot
+- **BOOL** : *false*
+
 #### gfxmode
 - Define which resolution should be used if VBE is used
 - **STRING** : *Empty by default*

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,11 @@
 #   Define if GRUB should use the submenu
 #   BOOL : false
 #
+# [*enable_cryptodisk*]
+#   Define if GRUB should check for encrypted disks and generate additional
+#   commands needed to access them during boot
+#   BOOL : false
+#
 # [*gfxmode*]
 #   Define which resolution should be used if VBE is used
 #   STRING : Empty by default
@@ -184,6 +189,7 @@ class grub2 (
   $disable_submenu             = $grub2::params::disable_submenu,
   $disable_uuid                = $grub2::params::disable_uuid,
   $distributor                 = $grub2::params::distributor,
+  $enable_cryptodisk           = $grub2::params::enable_cryptodisk,
   $gfxmode                     = $grub2::params::gfxmode,
   $hidden_timeout              = $grub2::params::hidden_timeout,
   $hidden_timeout_quiet        = $grub2::params::hidden_timeout_quiet,
@@ -225,6 +231,7 @@ class grub2 (
   validate_bool($disable_submenu)
   validate_bool($disable_uuid)
   validate_string($distributor)
+  validate_bool($enable_cryptodisk)
   validate_string($gfxmode)
   validate_string($hidden_timeout)
   validate_bool($hidden_timeout_quiet)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class grub2::params {
   $disable_recovery            = false
   $disable_submenu             = false
   $disable_uuid                = false
+  $enable_cryptodisk           = false
   $gfxmode                     = ''
   $hidden_timeout              = undef
   $hidden_timeout_quiet        = false

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -64,6 +64,10 @@ GRUB_DISABLE_RECOVERY="true"
 GRUB_DISABLE_SUBMENU="true"
 <% end -%>
 
+<% if @enable_cryptodisk -%>
+GRUB_ENABLE_CRYPTODISK="y"
+<% end -%>
+
 # Uncomment to get a beep at grub start
 <% if !@tune.empty? -%>
 GRUB_INIT_TUNE="<%= @tune %>"


### PR DESCRIPTION
When the GRUB_ENABLE_CRYPTODISK option is set the GRUB configuration can
be loaded from a LUKS-encrypted volume.

http://git.savannah.gnu.org/cgit/grub.git/tree/docs/grub.texi?h=2.02-rc2#n1473