### PR TITLE
add remove_grub_legacy parameter to remove grub-legacy packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,10 @@
 #   Install the GRUB packages and install GRUB in the MBR
 #   BOOL : false
 #
+# [*remove_grub_legacy*]
+#   Ensure the GRUB legacy is not installed
+#   BOOL : false
+#
 # [*package_ensure*]
 #   Puppet stuff, define in which state should be the GRUB packages
 #   STRING : 'present'
@@ -195,8 +199,10 @@ class grub2 (
   $hidden_timeout_quiet        = $grub2::params::hidden_timeout_quiet,
   $install_binary              = $grub2::params::install_binary,
   $install_grub                = $grub2::params::install_grub,
+  $remove_grub_legacy          = $grub2::params::remove_grub_legacy,
   $package_ensure              = $grub2::params::package_ensure,
   $package_name                = $grub2::params::package_name,
+  $package_name_legacy         = $grub2::params::package_name_legacy,
   $password                    = $grub2::params::password,
   $password_username           = $grub2::params::password_username,
   $password_pbkdf2_hash        = $grub2::params::password_pbkdf2_hash,
@@ -237,8 +243,10 @@ class grub2 (
   validate_bool($hidden_timeout_quiet)
   validate_absolute_path($install_binary)
   validate_bool($install_grub)
+  validate_bool($remove_grub_legacy)
   validate_string($package_ensure)
   validate_array($package_name)
+  validate_string($package_name_legacy)
   validate_bool($password)
   validate_string($password_username)
   validate_string($password_pbkdf2_hash)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,4 +17,11 @@ class grub2::install inherits grub2 {
     }
   }
 
+  if $grub2::remove_grub_legacy {
+    if $package_name_legacy {
+      package { $package_name_legacy:
+        ensure => absent,
+      }
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class grub2::params {
   $hidden_timeout              = undef
   $hidden_timeout_quiet        = false
   $install_grub                = false
+  $remove_grub_legacy          = false
   $package_ensure              = 'present'
   $password                    = false
   $password_username           = ''
@@ -35,39 +36,44 @@ class grub2::params {
 
   case $::osfamily {
     'Debian': {
-      $config_file       = '/etc/default/grub'
-      $distributor       = '$(lsb_release -i -s 2> /dev/null || echo Debian)'
-      $install_binary    = '/usr/sbin/grub-install'
-      $package_name      = [ 'grub-pc', 'grub-common' ]
-      $update_binary     = '/usr/sbin/update-grub'
+      $config_file         = '/etc/default/grub'
+      $distributor         = '$(lsb_release -i -s 2> /dev/null || echo Debian)'
+      $install_binary      = '/usr/sbin/grub-install'
+      $package_name        = [ 'grub-pc', 'grub-common' ]
+      $package_name_legacy = 'grub-legacy'
+      $update_binary       = '/usr/sbin/update-grub'
     }
     'Redhat': {
-      $config_file       = '/etc/default/grub'
-      $distributor       = "$(sed 's, release .*$,,g' /etc/system-release)"
-      $install_binary    = '/usr/sbin/grub2-install'
-      $package_name      = [ 'grub2', 'grub2-tools' ]
-      $update_binary     = '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
+      $config_file         = '/etc/default/grub'
+      $distributor         = "$(sed 's, release .*$,,g' /etc/system-release)"
+      $install_binary      = '/usr/sbin/grub2-install'
+      $package_name        = [ 'grub2', 'grub2-tools' ]
+      $package_name_legacy = undef
+      $update_binary       = '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
     }
     'Gentoo': {
-      $config_file       = '/etc/default/grub'
-      $distributor       = 'Gentoo'
-      $install_binary    = '/usr/sbin/grub2-install'
-      $package_name      = [ 'sys-boot/grub' ]
-      $update_binary     = '/usr/sbin/grub2-mkconfig -o /boot/grub/grub.cfg'
+      $config_file         = '/etc/default/grub'
+      $distributor         = 'Gentoo'
+      $install_binary      = '/usr/sbin/grub2-install'
+      $package_name        = [ 'sys-boot/grub' ]
+      $package_name_legacy = undef
+      $update_binary       = '/usr/sbin/grub2-mkconfig -o /boot/grub/grub.cfg'
     }
     'Suse': {
-      $config_file       = '/etc/default/grub'
-      $distributor       = '$(lsb_release -i -r -s 2> /dev/null || echo SUSE)'
-      $install_binary    = '/usr/sbin/grub2-install'
-      $package_name      = [ 'grub2' ]
-      $update_binary     = '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
+      $config_file         = '/etc/default/grub'
+      $distributor         = '$(lsb_release -i -r -s 2> /dev/null || echo SUSE)'
+      $install_binary      = '/usr/sbin/grub2-install'
+      $package_name        = [ 'grub2' ]
+      $package_name_legacy = undef
+      $update_binary       = '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
     }
     'Archlinux': {
-      $config_file       = '/etc/default/grub'
-      $distributor       = '$(lsb_release -i -r -s 2> /dev/null || echo Archlinux)'
-      $install_binary    = '/usr/bin/grub-install'
-      $package_name      = [ 'grub' ]
-      $update_binary     = '/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg'
+      $config_file         = '/etc/default/grub'
+      $distributor         = '$(lsb_release -i -r -s 2> /dev/null || echo Archlinux)'
+      $install_binary      = '/usr/bin/grub-install'
+      $package_name        = [ 'grub' ]
+      $package_name_legacy = undef
+      $update_binary       = '/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg'
     }
     default: {
       fail("The ${module_name} module is not supported on ${::operatingsystem}")


### PR DESCRIPTION
Some distributions allow to have `grub-legacy` and `grub2` to be installed.
It is now possible to remove grub-legacy packages by setting
`$remove_grub_legacy` to `true` (defaults to `false`).

Signed-off-by: Florian Klink <flokli@flokli.de>