### PR TITLE
Fix module for non-password setups.

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,10 +1,16 @@
 # class: grub2::update: See README for documentation
 class grub2::update inherits grub2 {
 
+  if $grub2::password {
+    $exec_subscribe = [ File[$grub2::config_file], File[$grub2::password_file], ]
+  } else {
+    $exec_subscribe = File[$grub2::config_file]
+  }
+
   if $grub2::update_grub {
     exec { 'Update GRUB':
       command     => $grub2::update_binary,
-      subscribe   => [File[$grub2::config_file], File[$grub2::password_file]],
+      subscribe   => $exec_subscribe,
       refreshonly => true,
     }
   }


### PR DESCRIPTION
This fixes a regression introduced with #36. It broken the module for
all setups which do not set grub2::password by always letting
grub::update subscribe to the password file.

Fixes #40