### PR TITLE
new parameter GRUB_PRELOAD_MODULES added

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ This module manages GRUB 2 bootloader
 - Set PBKDF2 password hash generated via grub-mkpasswd-pbkdf2 or grub2-mkpasswd-pbkdf2 commands
 - **STRING** : *Empty by default*
 
+#### preload_modules
+- Preload additional modules
+- **STRING** : *Empty by default*
+
 #### recordfail_timeout
 - Set default timeout value for GRUB2.
   Useful to stop headless machines stalling during boot.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,10 @@
 #   Password hash generated via grub-mkpasswd-pbkdf2 or grub2-mkpasswd-pbkdf2 commands
 #   STRING : 'present'
 #
+# ['preload_modules']
+#   Preload additional modules
+#   STRING : Empty by default
+#
 # [*recordfail_timeout*]
 #   Set default timeout value for GRUB.
 #   Without this set, headless machines may stall during boot
@@ -207,6 +211,7 @@ class grub2 (
   $password_file               = $grub2::params::password_file,
   $password_username           = $grub2::params::password_username,
   $password_pbkdf2_hash        = $grub2::params::password_pbkdf2_hash,
+  $preload_modules             = $grub2::params::preload_modules,
   $recordfail_timeout          = $grub2::params::recordfail_timeout,
   $save_default                = $grub2::params::save_default,
   $serial_command              = $grub2::params::serial_command,
@@ -252,6 +257,7 @@ class grub2 (
   validate_absolute_path($password_file)
   validate_string($password_username)
   validate_string($password_pbkdf2_hash)
+  validate_string($preload_modules)
   validate_integer($recordfail_timeout)
   validate_bool($save_default)
   validate_string($serial_command)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class grub2::params {
   $password_username           = ''
   $password_pbkdf2_hash        = ''
   $password_template           = 'grub2/50_password.erb'
+  $preload_modules             = ''
   $recordfail_timeout          = 5
   $save_default                = false
   $serial_command              = ''

--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -97,3 +97,9 @@ GRUB_SAVEDEFAULT="<%= @save_default %>"
 <% if @background_image -%>
 GRUB_BACKGROUND="<%= @background_image %>"
 <% end -%>
+
+# This option may be set to a list of GRUB module names separated by spaces
+# Each module will be loaded as early as possible, at the start of grub.cfg
+<% if !@preload_modules.empty? -%>
+GRUB_PRELOAD_MODULES="<%= @preload_modules %>"
+<% end -%>


### PR DESCRIPTION
We need some modules preloaded during boot. Therefore we have added the grub2 parameter GRUB_PRELOAD_MODULES.