### PR TITLE
Force GRUB_DISABLE_OS_PROBER even if false

### DIFF
--- a/templates/default_grub.erb
+++ b/templates/default_grub.erb
@@ -85,9 +85,7 @@ GRUB_CMDLINE_XEN="<%= @cmdline_xen %>"
 <% else %>
 <% end -%>
 
-<% if @disable_os_prober -%>
 GRUB_DISABLE_OS_PROBER="<%= @disable_os_prober %>"
-<% end -%>
 
 <% if @suse_btrfs_snapshot_booting -%>
 SUSE_BTRFS_SNAPSHOT_BOOTING="<%= @suse_btrfs_snapshot_booting %>"


### PR DESCRIPTION
OS prober is now disabled by default since GRUB 2.06 so the config needs to be here