### PR TITLE
Enable use of "$password_username" and "$password_pbkdf2_hash" parameter.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,8 @@
 # @param password Whether to manage password file.
 # @param password_file Path to password file.
 # @param password_template Template used for password file.
+# @param password_username GRUB superuser name.
+# @param password_pbkdf2_hash PBKDF2 hash for GRUB password.
 # @param default_entry GRUB default entry index/name.
 # @param timeout_style Timeout style.
 # @param timeout_style_disable Whether hidden timeout overrides timeout_style.
@@ -37,6 +39,8 @@ class grub2::config (
   Boolean $password,
   Stdlib::Absolutepath $password_file,
   String $password_template,
+  String $password_username,
+  String $password_pbkdf2_hash,
   String $default_entry,
   String $timeout_style,
   Boolean $timeout_style_disable,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,6 +75,10 @@ class grub2::config (
   }
 
   if $password {
+    if $password_username == '' or $password_pbkdf2_hash == '' {
+      fail('grub2::config: password_username and password_pbkdf2_hash must be non-empty when password is enabled')
+    }
+
     file { $password_file:
       ensure  => file,
       content => template($password_template),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,8 @@ class grub2 (
     password                    => $password,
     password_file               => $password_file,
     password_template           => $password_template,
+    password_username           => $password_username,
+    password_pbkdf2_hash        => $password_pbkdf2_hash,
     default_entry               => $default_entry,
     timeout_style               => $timeout_style,
     timeout_style_disable       => $timeout_style_disable,


### PR DESCRIPTION
Even if the parameters "_$password_username_" and "_$password_pbkdf2_hash_" are set, they are not passed to the class "**grub2::config**" by "_init.pp_". This commit fixes this situation and transfers the values, if they are set, to the "**grub2::config**" class. The logic of the file then sets the values into the "_$password_file_" file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GRUB superuser authentication using PBKDF2-hashed passwords, enabling secure bootloader password configuration.
  * Configuration now accepts and forwards both a superuser name and its PBKDF2 hash for use in authentication.

* **Bug Fixes**
  * When password protection is enabled, the configuration now validates that both a username and PBKDF2 hash are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->